### PR TITLE
fix image meta - remove link and comment image:url, image:secure_url

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,9 +10,8 @@
     <meta content="telephone=no" name="format-detection">
     <meta property="og:title" content="CV - Gur Yaniv"/>
     <meta property="og:image" content="https://raw.githubusercontent.com/guryaniv/CVSite/master/img/GurCVIcon.png"/>
-    <meta property="og:image:url" content="https://raw.githubusercontent.com/guryaniv/CVSite/master/img/GurCVIcon.png"/>
-    <meta property="og:image:secure_url" content="https://raw.githubusercontent.com/guryaniv/CVSite/master/img/GurCVIcon.png"/>
-    <link rel="image_src" href="/img/GurCVIcon.png"/>
+<!--    <meta property="og:image:url" content="https://raw.githubusercontent.com/guryaniv/CVSite/master/img/GurCVIcon.png"/>-->
+<!--    <meta property="og:image:secure_url" content="https://raw.githubusercontent.com/guryaniv/CVSite/master/img/GurCVIcon.png"/>-->
     <meta property="og:description" content="Full CV and contact details"/>
 <!--    <meta property="og:url" content="http://GurYaniv.com" />-->
 


### PR DESCRIPTION
It worked for facebook share, but not on linkedin, trying to fix for linkein